### PR TITLE
feat:make credit components

### DIFF
--- a/JOLUV/src/components/displayCredits/eachCredits.tsx
+++ b/JOLUV/src/components/displayCredits/eachCredits.tsx
@@ -1,0 +1,44 @@
+// src/components/EachCredits.tsx (수정된 Tailwind CSS)
+
+import React from 'react';
+import type { eachCredits } from '../../types/totalCredits';
+
+interface CreditProgressProps {
+  data: eachCredits;
+}
+// 전공학점과 교양학점 표시하는 컴포넌트 (각각의 점수를 변수로 입력받음)
+function EachCredits({ data }: CreditProgressProps) {
+  const { MajorCredits, CultureCredits } = data;
+
+  return (
+
+    <div className="flex justify-center space-x-4 w-full max-w-4xl mx-auto h-full"> 
+        
+        {/* 1. 전공 학점 섹션: flex-1 적용하여 공간을 균등하게 차지하도록 함 */}
+        <div className="flex-1 p-6 border border-gray-200 rounded-xl shadow-lg bg-white space-y-4 h-full">
+            
+            <h2 className="text-2xl font-semibold text-center text-gray-800 border-b pb-3">
+                전공 학점
+            </h2>
+
+            <div className="flex justify-center text-4xl font-medium pt-3">
+                 <span className="text-blue-600 font-bold">{MajorCredits}학점</span>
+            </div>
+        </div>
+        
+        {/* 2. 교양 학점 섹션: flex-1 적용하여 공간을 균등하게 차지하도록 함 */}
+        <div className="flex-1  p-6 border border-gray-200 rounded-xl shadow-lg bg-white space-y-4 h-full">
+      
+            <h2 className="text-2xl font-semibold text-center text-gray-800 border-b pb-3">
+                교양 학점
+            </h2>
+
+            <div className="flex justify-center text-4xl font-medium pt-3">
+                <span className="text-blue-600 font-bold">{CultureCredits}학점</span>
+            </div>
+        </div>
+    </div>
+  );
+}
+
+export default EachCredits;

--- a/JOLUV/src/components/displayCredits/totalCredits.tsx
+++ b/JOLUV/src/components/displayCredits/totalCredits.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+
+import type { graduacteCradits } from '../../types/totalCredits';
+
+// interface : 따라야 하는 규칙. 요구사항
+interface CreditProgressProps {
+  data: graduacteCradits;
+}
+
+// React.FC를 사용하지 않고 함수 컴포넌트로 정의합니다.
+function TotalCredits({ data }: CreditProgressProps) {
+  const { totalCredits, completedCredits } = data;
+
+  // 이수율 계산 (백분율)
+  const progressPercentage = (completedCredits / totalCredits) * 100;
+  // 소수점 1자리까지 표시
+  const displayPercentage = progressPercentage.toFixed(1);
+  // 진행률 바의 너비를 100%로 제한 (만약 초과 이수하더라도)
+  const progressBarWidth = Math.min(progressPercentage, 100);
+
+  return (
+    // credit-progress-container
+    <div className="max-w-xl mx-auto p-6 border border-gray-200 rounded-xl shadow-lg bg-white space-y-4 h-full">
+      
+      {/* credit-progress-title */}
+      <h2 className="text-2xl font-semibold text-center text-gray-800 border-b pb-3">
+        졸업 학점 이수 현황
+      </h2>
+
+      {/* 학점 정보 표시 (credit-info) */}
+      <div className="flex justify-center text-xl font-medium space-x-1">
+        <span className="text-blue-600 font-bold">{completedCredits}학점</span>
+        <span className="text-gray-500"> / </span>
+        <span className="text-gray-800">{totalCredits}학점</span>
+      </div>
+
+      {/* 진행률 바 (progress-bar-base) */}
+      <div className="w-full bg-gray-200 rounded-full h-3">
+        <div
+          // progress-bar-fill
+          className="h-3 rounded-full bg-blue-500 transition-all duration-500 ease-in-out"
+          style={{ width: `${progressBarWidth}%` }}
+          // 접근성을 위한 속성
+          aria-valuenow={completedCredits}
+          aria-valuemin={0}
+          aria-valuemax={totalCredits}
+        ></div>
+      </div>
+
+      {/* 백분율 표시 (percentage-display) */}
+      <div className="text-center text-lg font-bold text-gray-700 pt-1">
+        {displayPercentage}% 이수
+      </div>
+    </div>
+  );
+}
+
+export default TotalCredits;

--- a/JOLUV/src/pages/main/Mainpage.tsx
+++ b/JOLUV/src/pages/main/Mainpage.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import TotalCredits from '../../components/displayCredits/totalCredits';
+import  EachCredits from '../../components/displayCredits/eachCredits';
 
 // 아이콘을 위한 간단한 placeholder 컴포넌트
 const IconPlaceholder: React.FC<{ className?: string }> = ({ className }) => (
@@ -98,6 +100,19 @@ const MainPage: React.FC = () => {
             <li className="p-2">항목 3</li>
           </ul>
         </div>
+        {/*이부분이 각각의 학점 관련 컴포넌트를 가로 배치해둔 것 */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex space-x-8 items-stretch"> 
+            {/* 1. 왼쪽 컴포넌트: 전체 학점 현황 */}
+            <div className="flex-1">
+              <TotalCredits data={{totalCredits: 120, completedCredits:90}}/>
+            </div>
+            {/* 2. 오른쪽 컴포넌트: 전공/교양 학점 현황 */}
+            <div className="flex-1">
+                <EachCredits data={{MajorCredits:50, CultureCredits:30}}/>
+            </div>
+        </div>
+      </div>
       </main>
     </div>
   );

--- a/JOLUV/src/types/totalCredits.ts
+++ b/JOLUV/src/types/totalCredits.ts
@@ -1,0 +1,10 @@
+export interface graduacteCradits{
+    // interface는 export가 가능하고, 선언 병합이 가능해 자동으로 합쳐짐
+    totalCredits: number; // 총 졸업 학점
+    completedCredits : number; // 이수한 학점
+}
+
+export interface eachCredits{
+    MajorCredits : number; // 전공 학점
+    CultureCredits : number; // 교양 학점
+}


### PR DESCRIPTION
총 이수 학점 현황 / ( 전공학점 / 교양학점 )
이 나오는 구성으로 컴포넌트 생성 완료.

컴포넌트는 총 2개로 생성.
totalCredits : 전체 학점 도출
eachCredits : 전공, 교양 학점 도출

전체 학점은 진행률을 백분율로 진행도를 시각적으로 확인이 가능하며,
백분율을 소수점 첫째자리에서 반올림 하는 방식으로 구성.

현재 컴포넌트를 넣을 공간이 마땅치 않아
mainpage에 넣어둔 상태. 
mainpage에서 그냥 div뭉치를 다른데로 옮기면 되는 문제라
차후 페이지 개선 중 이동 예정.